### PR TITLE
- UI modifications and improvements

### DIFF
--- a/src/G5.Controls/GameTableControl.Designer.cs
+++ b/src/G5.Controls/GameTableControl.Designer.cs
@@ -28,10 +28,12 @@
         /// </summary>
         private void InitializeComponent()
         {
+            this.buttonNext = new System.Windows.Forms.Button();
             this.buttonFold = new System.Windows.Forms.Button();
             this.buttonCheckCall = new System.Windows.Forms.Button();
             this.buttonBetRaise = new System.Windows.Forms.Button();
-            this.buttonNext = new System.Windows.Forms.Button();
+            this.buttonAllin = new System.Windows.Forms.Button();
+            this.textBoxEditBet = new System.Windows.Forms.TextBox();
             this.labelInPot0 = new System.Windows.Forms.Label();
             this.labelInPot1 = new System.Windows.Forms.Label();
             this.labelInPot2 = new System.Windows.Forms.Label();
@@ -53,6 +55,8 @@
             this.pictureBoxButton5 = new System.Windows.Forms.PictureBox();
             this.pictureBoxTable = new System.Windows.Forms.PictureBox();
             this._trackBarRaiseAmm = new System.Windows.Forms.TrackBar();
+            this.labelHandsPlayed = new System.Windows.Forms.Label();
+            this.labelhands = new System.Windows.Forms.Label();
             this.playerControlSmall5 = new G5.Controls.PlayerControlSmall();
             this.playerControlSmall4 = new G5.Controls.PlayerControlSmall();
             this.playerControlSmall3 = new G5.Controls.PlayerControlSmall();
@@ -73,6 +77,17 @@
             ((System.ComponentModel.ISupportInitialize)(this.pictureBoxTable)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this._trackBarRaiseAmm)).BeginInit();
             this.SuspendLayout();
+            // 
+            // buttonNext
+            // 
+            this.buttonNext.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.buttonNext.Location = new System.Drawing.Point(671, 485);
+            this.buttonNext.Name = "buttonNext";
+            this.buttonNext.Size = new System.Drawing.Size(75, 23);
+            this.buttonNext.TabIndex = 16;
+            this.buttonNext.Text = "Next";
+            this.buttonNext.UseVisualStyleBackColor = true;
+            this.buttonNext.Click += new System.EventHandler(this.buttonNext_Click);
             // 
             // buttonFold
             // 
@@ -107,16 +122,25 @@
             this.buttonBetRaise.UseVisualStyleBackColor = true;
             this.buttonBetRaise.Click += new System.EventHandler(this.buttonBetRaise_Click);
             // 
-            // buttonNext
+            // buttonAllin
             // 
-            this.buttonNext.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonNext.Location = new System.Drawing.Point(671, 485);
-            this.buttonNext.Name = "buttonNext";
-            this.buttonNext.Size = new System.Drawing.Size(75, 23);
-            this.buttonNext.TabIndex = 16;
-            this.buttonNext.Text = "Next";
-            this.buttonNext.UseVisualStyleBackColor = true;
-            this.buttonNext.Click += new System.EventHandler(this.buttonNext_Click);
+            this.buttonAllin.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.buttonAllin.Location = new System.Drawing.Point(462, 429);
+            this.buttonAllin.Name = "buttonAllin";
+            this.buttonAllin.Size = new System.Drawing.Size(75, 23);
+            this.buttonAllin.TabIndex = 10;
+            this.buttonAllin.Text = "All-in";
+            this.buttonAllin.UseVisualStyleBackColor = true;
+            this.buttonAllin.Click += new System.EventHandler(this.buttonAllin_Click);
+            // 
+            // textBoxEditBet
+            // 
+            this.textBoxEditBet.Location = new System.Drawing.Point(462, 459);
+            this.textBoxEditBet.Name = "textBoxEditBet";
+            this.textBoxEditBet.Size = new System.Drawing.Size(75, 20);
+            this.textBoxEditBet.TabIndex = 11;
+            this.textBoxEditBet.TextChanged += new System.EventHandler(this.textBoxEditBet_TextChanged);
+            this.textBoxEditBet.KeyDown += new System.Windows.Forms.KeyEventHandler(this.textBoxEditBet_KeyDown);
             // 
             // labelInPot0
             // 
@@ -132,7 +156,7 @@
             // 
             this.labelInPot1.AutoSize = true;
             this.labelInPot1.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.labelInPot1.Location = new System.Drawing.Point(595, 256);
+            this.labelInPot1.Location = new System.Drawing.Point(138, 256);
             this.labelInPot1.Name = "labelInPot1";
             this.labelInPot1.Size = new System.Drawing.Size(22, 16);
             this.labelInPot1.TabIndex = 24;
@@ -142,7 +166,7 @@
             // 
             this.labelInPot2.AutoSize = true;
             this.labelInPot2.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.labelInPot2.Location = new System.Drawing.Point(595, 110);
+            this.labelInPot2.Location = new System.Drawing.Point(159, 85);
             this.labelInPot2.Name = "labelInPot2";
             this.labelInPot2.Size = new System.Drawing.Size(22, 16);
             this.labelInPot2.TabIndex = 25;
@@ -162,7 +186,7 @@
             // 
             this.labelInPot4.AutoSize = true;
             this.labelInPot4.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.labelInPot4.Location = new System.Drawing.Point(159, 85);
+            this.labelInPot4.Location = new System.Drawing.Point(595, 110);
             this.labelInPot4.Name = "labelInPot4";
             this.labelInPot4.Size = new System.Drawing.Size(22, 16);
             this.labelInPot4.TabIndex = 27;
@@ -172,7 +196,7 @@
             // 
             this.labelInPot5.AutoSize = true;
             this.labelInPot5.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.labelInPot5.Location = new System.Drawing.Point(138, 256);
+            this.labelInPot5.Location = new System.Drawing.Point(595, 256);
             this.labelInPot5.Name = "labelInPot5";
             this.labelInPot5.Size = new System.Drawing.Size(22, 16);
             this.labelInPot5.TabIndex = 28;
@@ -245,11 +269,11 @@
             // pictureBoxButton4
             // 
             this.pictureBoxButton4.Image = global::G5.Controls.Resources.DealerButton;
-            this.pictureBoxButton4.Location = new System.Drawing.Point(123, 107);
+            this.pictureBoxButton4.Location = new System.Drawing.Point(576, 85);
             this.pictureBoxButton4.Name = "pictureBoxButton4";
             this.pictureBoxButton4.Size = new System.Drawing.Size(30, 22);
             this.pictureBoxButton4.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
-            this.pictureBoxButton4.TabIndex = 15;
+            this.pictureBoxButton4.TabIndex = 14;
             this.pictureBoxButton4.TabStop = false;
             this.pictureBoxButton4.Visible = false;
             // 
@@ -260,29 +284,29 @@
             this.pictureBoxButton3.Name = "pictureBoxButton3";
             this.pictureBoxButton3.Size = new System.Drawing.Size(30, 22);
             this.pictureBoxButton3.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
-            this.pictureBoxButton3.TabIndex = 14;
+            this.pictureBoxButton3.TabIndex = 13;
             this.pictureBoxButton3.TabStop = false;
             this.pictureBoxButton3.Visible = false;
             // 
             // pictureBoxButton2
             // 
             this.pictureBoxButton2.Image = global::G5.Controls.Resources.DealerButton;
-            this.pictureBoxButton2.Location = new System.Drawing.Point(576, 85);
+            this.pictureBoxButton2.Location = new System.Drawing.Point(123, 107);
             this.pictureBoxButton2.Name = "pictureBoxButton2";
             this.pictureBoxButton2.Size = new System.Drawing.Size(30, 22);
             this.pictureBoxButton2.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
-            this.pictureBoxButton2.TabIndex = 13;
+            this.pictureBoxButton2.TabIndex = 12;
             this.pictureBoxButton2.TabStop = false;
             this.pictureBoxButton2.Visible = false;
             // 
             // pictureBoxButton1
             // 
             this.pictureBoxButton1.Image = global::G5.Controls.Resources.DealerButton;
-            this.pictureBoxButton1.Location = new System.Drawing.Point(576, 278);
+            this.pictureBoxButton1.Location = new System.Drawing.Point(102, 250);
             this.pictureBoxButton1.Name = "pictureBoxButton1";
             this.pictureBoxButton1.Size = new System.Drawing.Size(30, 22);
             this.pictureBoxButton1.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
-            this.pictureBoxButton1.TabIndex = 12;
+            this.pictureBoxButton1.TabIndex = 11;
             this.pictureBoxButton1.TabStop = false;
             this.pictureBoxButton1.Visible = false;
             // 
@@ -293,18 +317,18 @@
             this.pictureBoxButton0.Name = "pictureBoxButton0";
             this.pictureBoxButton0.Size = new System.Drawing.Size(30, 22);
             this.pictureBoxButton0.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
-            this.pictureBoxButton0.TabIndex = 11;
+            this.pictureBoxButton0.TabIndex = 10;
             this.pictureBoxButton0.TabStop = false;
             this.pictureBoxButton0.Visible = false;
             // 
             // pictureBoxButton5
             // 
             this.pictureBoxButton5.Image = global::G5.Controls.Resources.DealerButton;
-            this.pictureBoxButton5.Location = new System.Drawing.Point(102, 250);
+            this.pictureBoxButton5.Location = new System.Drawing.Point(576, 278);
             this.pictureBoxButton5.Name = "pictureBoxButton5";
             this.pictureBoxButton5.Size = new System.Drawing.Size(30, 22);
             this.pictureBoxButton5.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
-            this.pictureBoxButton5.TabIndex = 10;
+            this.pictureBoxButton5.TabIndex = 15;
             this.pictureBoxButton5.TabStop = false;
             this.pictureBoxButton5.Visible = false;
             // 
@@ -324,17 +348,41 @@
             // 
             // _trackBarRaiseAmm
             // 
-            this._trackBarRaiseAmm.Location = new System.Drawing.Point(300, 434);
+            this._trackBarRaiseAmm.AutoSize = false;
+            this._trackBarRaiseAmm.Location = new System.Drawing.Point(300, 429);
             this._trackBarRaiseAmm.Name = "_trackBarRaiseAmm";
-            this._trackBarRaiseAmm.Size = new System.Drawing.Size(237, 45);
+            this._trackBarRaiseAmm.Size = new System.Drawing.Size(153, 50);
             this._trackBarRaiseAmm.TabIndex = 39;
             this._trackBarRaiseAmm.Scroll += new System.EventHandler(this.trackBarRaiseAmm_Scroll);
+            // 
+            // labelHandsPlayed
+            // 
+            this.labelHandsPlayed.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.labelHandsPlayed.Location = new System.Drawing.Point(90, 14);
+            this.labelHandsPlayed.Name = "labelHandsPlayed";
+            this.labelHandsPlayed.Size = new System.Drawing.Size(60, 15);
+            this.labelHandsPlayed.TabIndex = 41;
+            this.labelHandsPlayed.Text = "0";
+            this.labelHandsPlayed.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // labelhands
+            // 
+            this.labelhands.BackColor = System.Drawing.SystemColors.ControlText;
+            this.labelhands.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.labelhands.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.labelhands.ForeColor = System.Drawing.SystemColors.ControlLightLight;
+            this.labelhands.Location = new System.Drawing.Point(35, 11);
+            this.labelhands.Name = "labelhands";
+            this.labelhands.Size = new System.Drawing.Size(118, 21);
+            this.labelhands.TabIndex = 40;
+            this.labelhands.Text = "Hands :";
+            this.labelhands.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // playerControlSmall5
             // 
             this.playerControlSmall5.BackColor = System.Drawing.Color.Transparent;
             this.playerControlSmall5.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.playerControlSmall5.Location = new System.Drawing.Point(14, 278);
+            this.playerControlSmall5.Location = new System.Drawing.Point(612, 278);
             this.playerControlSmall5.Name = "playerControlSmall5";
             this.playerControlSmall5.Size = new System.Drawing.Size(118, 56);
             this.playerControlSmall5.TabIndex = 22;
@@ -343,7 +391,7 @@
             // 
             this.playerControlSmall4.BackColor = System.Drawing.Color.Transparent;
             this.playerControlSmall4.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.playerControlSmall4.Location = new System.Drawing.Point(35, 45);
+            this.playerControlSmall4.Location = new System.Drawing.Point(612, 45);
             this.playerControlSmall4.Name = "playerControlSmall4";
             this.playerControlSmall4.Size = new System.Drawing.Size(118, 56);
             this.playerControlSmall4.TabIndex = 21;
@@ -361,16 +409,17 @@
             // 
             this.playerControlSmall2.BackColor = System.Drawing.Color.Transparent;
             this.playerControlSmall2.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.playerControlSmall2.Location = new System.Drawing.Point(612, 45);
+            this.playerControlSmall2.Location = new System.Drawing.Point(35, 45);
             this.playerControlSmall2.Name = "playerControlSmall2";
             this.playerControlSmall2.Size = new System.Drawing.Size(118, 56);
             this.playerControlSmall2.TabIndex = 19;
+            this.playerControlSmall2.Load += new System.EventHandler(this.playerControlSmall2_Load);
             // 
             // playerControlSmall1
             // 
             this.playerControlSmall1.BackColor = System.Drawing.Color.Transparent;
             this.playerControlSmall1.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.playerControlSmall1.Location = new System.Drawing.Point(612, 278);
+            this.playerControlSmall1.Location = new System.Drawing.Point(14, 278);
             this.playerControlSmall1.Name = "playerControlSmall1";
             this.playerControlSmall1.Size = new System.Drawing.Size(118, 56);
             this.playerControlSmall1.TabIndex = 18;
@@ -388,7 +437,8 @@
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.Controls.Add(this._trackBarRaiseAmm);
+            this.Controls.Add(this.labelHandsPlayed);
+            this.Controls.Add(this.labelhands);
             this.Controls.Add(this.listBoxLog);
             this.Controls.Add(this.labelPot);
             this.Controls.Add(this.pictureRiver);
@@ -415,9 +465,12 @@
             this.Controls.Add(this.pictureBoxButton1);
             this.Controls.Add(this.pictureBoxButton0);
             this.Controls.Add(this.pictureBoxButton5);
-            this.Controls.Add(this.buttonBetRaise);
-            this.Controls.Add(this.buttonCheckCall);
             this.Controls.Add(this.buttonFold);
+            this.Controls.Add(this.buttonCheckCall);
+            this.Controls.Add(this.buttonBetRaise);
+            this.Controls.Add(this.buttonAllin);
+            this.Controls.Add(this.textBoxEditBet);
+            this.Controls.Add(this._trackBarRaiseAmm);
             this.Controls.Add(this.pictureBoxTable);
             this.Name = "GameTableControl";
             this.Size = new System.Drawing.Size(750, 511);
@@ -442,16 +495,19 @@
         #endregion
 
         private System.Windows.Forms.PictureBox pictureBoxTable;
+        public System.Windows.Forms.Button buttonNext;
         private System.Windows.Forms.Button buttonFold;
         private System.Windows.Forms.Button buttonCheckCall;
         private System.Windows.Forms.Button buttonBetRaise;
+        public System.Windows.Forms.Button buttonAllin;
+        public System.Windows.Forms.TextBox textBoxEditBet;
+        private System.Windows.Forms.TrackBar _trackBarRaiseAmm;
         private System.Windows.Forms.PictureBox pictureBoxButton5;
         private System.Windows.Forms.PictureBox pictureBoxButton0;
         private System.Windows.Forms.PictureBox pictureBoxButton1;
         private System.Windows.Forms.PictureBox pictureBoxButton2;
         private System.Windows.Forms.PictureBox pictureBoxButton3;
         private System.Windows.Forms.PictureBox pictureBoxButton4;
-        private System.Windows.Forms.Button buttonNext;
         private PlayerControlSmall playerControlSmall0;
         private PlayerControlSmall playerControlSmall1;
         private PlayerControlSmall playerControlSmall2;
@@ -471,6 +527,7 @@
         private System.Windows.Forms.PictureBox pictureRiver;
         private System.Windows.Forms.Label labelPot;
         private System.Windows.Forms.ListBox listBoxLog;
-        private System.Windows.Forms.TrackBar _trackBarRaiseAmm;
+        private System.Windows.Forms.Label labelHandsPlayed;
+        private System.Windows.Forms.Label labelhands;
     }
 }

--- a/src/G5.Controls/PlayerControlSmall.cs
+++ b/src/G5.Controls/PlayerControlSmall.cs
@@ -47,6 +47,8 @@ namespace G5.Controls
             }
 
             this.BackColor = (toAct) ? Color.LightGray : Color.DimGray;
+            labelStack.ForeColor = (toAct) ? Color.Black : Color.White;
+            labelName.ForeColor = (toAct) ? Color.Black : Color.White;
         }
     }
 }

--- a/src/G5.Controls/Resources.Designer.cs
+++ b/src/G5.Controls/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace G5.Controls {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/src/G5.Logic/BotGameState.cs
+++ b/src/G5.Logic/BotGameState.cs
@@ -771,6 +771,15 @@ namespace G5.Logic
             goToNextPlayer();
         }
 
+        public void playerGoesAllIn()
+        {
+            Console.WriteLine(getPlayerToAct().Name + " goes All-in");
+            _currentHand.addAction(_street, getPlayerToAct().Name, ActionType.AllIn, 0);
+
+            getPlayerToAct().GoesAllIn();
+            goToNextPlayer();
+        }
+
         public struct BotDecision
         {
             public ActionType actionType;

--- a/src/G5.Logic/Card.cs
+++ b/src/G5.Logic/Card.cs
@@ -44,12 +44,12 @@ namespace G5.Logic
         /// <summary>
         /// Broj/rank karte
         /// </summary>
-        public Rank rank { get; private set; }
+        public Rank rank { get; set; }
 
         /// <summary>
         /// Boja/znak/suite karte
         /// </summary>
-        public Suite suite { get; private set; }
+        public Suite suite { get; set; }
 
         public Card(int value) : this()
         {

--- a/src/G5.Logic/Player.cs
+++ b/src/G5.Logic/Player.cs
@@ -15,6 +15,7 @@ namespace G5.Logic
         public PlayerModel Model { get; set; }
 
         public int Stack { get; private set; }
+        public int BetAmount { get; set; }
         public int MoneyInPot { get; private set; }
         public int MoneyWon { get; private set; }
 
@@ -22,6 +23,7 @@ namespace G5.Logic
         {
             Name = aName;
             Stack = stack;
+            BetAmount = 0;
             MoneyInPot = 0;
             MoneyWon = 0;
 
@@ -38,6 +40,7 @@ namespace G5.Logic
         {
             Name = oldPlayer.Name;
             Stack = oldPlayer.Stack;
+            BetAmount = oldPlayer.BetAmount;
             MoneyInPot = oldPlayer.MoneyInPot;
             MoneyWon = oldPlayer.MoneyWon;
 
@@ -69,6 +72,7 @@ namespace G5.Logic
         {
             Debug.Assert(StatusInHand == Status.ToAct);
             StatusInHand = Status.ToAct;
+            BetAmount = amount;
             MoneyInPot += amount;
             Stack -= amount;
         }
@@ -93,6 +97,7 @@ namespace G5.Logic
             StatusInHand = Status.Acted;
             LastAction = ActionType.Call;
 
+            BetAmount = amount;
             MoneyInPot += amount;
             Stack -= amount;
         }
@@ -104,6 +109,7 @@ namespace G5.Logic
             LastAction = ActionType.Raise;
 
             int amount = toAmount - MoneyInPot;
+            BetAmount = amount;
             MoneyInPot = toAmount;
             Stack -= amount;
 
@@ -120,7 +126,8 @@ namespace G5.Logic
             Debug.Assert(StatusInHand == Status.ToAct);
             StatusInHand = Status.AllIn;
             LastAction = ActionType.AllIn;
-
+            
+            BetAmount = amount;
             MoneyInPot += amount;
             Stack = 0;
 
@@ -145,6 +152,7 @@ namespace G5.Logic
         {
             PrevStreetAction = LastAction;
             LastAction = ActionType.Fold;
+            BetAmount = 0;
         }
 
         public void ResetHand()
@@ -154,6 +162,7 @@ namespace G5.Logic
             PrevStreetAction = ActionType.Fold;
             Range.Reset();
 
+            BetAmount = 0;
             MoneyInPot = 0;
             MoneyWon = 0;
         }

--- a/src/G5.PlayVsBots/Properties/Resources.Designer.cs
+++ b/src/G5.PlayVsBots/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace G5.PlayVsBots.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/src/G5.PlayVsBots/Properties/Settings.Designer.cs
+++ b/src/G5.PlayVsBots/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace G5.PlayVsBots.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.1.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.10.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/src/G5Gym/PythonAPI.cs
+++ b/src/G5Gym/PythonAPI.cs
@@ -221,7 +221,7 @@ namespace G5Gym
 
         public void goToFlop(string gameName, string card0, string card1, string card2)
         {
-            List<Card> cards = [new Card(card0), new Card(card1), new Card(card2)];
+            List<Card> cards = new List<Card> { new Card(card0), new Card(card1), new Card(card2) };
             _botGameStates[gameName].goToNextStreet(cards);
         }
 


### PR DESCRIPTION
Some modifications and improvements of the UI that suits for my personal use and way I want the g5bot works (hope that also may suits for you):

- the direction of play is now in the correct clockwise direction

- automatically click Next button so that the g5bot is playing stand-alone to do long run challenge against other bots (like OpenHoldem)

- labelInPots now display betsizes of players instead of moneyInPot

- added bb/100 won (on the current session) and blind size on the titlebar

- added a number of hands played (on the current session) label on top for convienence